### PR TITLE
remove unused methods

### DIFF
--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -391,13 +391,6 @@ class Prime
       @ulticheck_next_squared = 121   # @primes[@ulticheck_index + 1] ** 2
     end
 
-    # Returns the cached prime numbers.
-    def cache
-      @primes
-    end
-    alias primes cache
-    alias primes_so_far cache
-
     # Returns the +index+th prime number.
     #
     # +index+ is a 0-based index.


### PR DESCRIPTION
remove following methods
- TrialDivision#cache
- TrialDivision#primes
- TrialDivision#primes_so_far

TrialDivision class is undocumented officially, so this class used only internally.
yugui san moved prime library from mathn to prime in 2008, and then she might forget to delete these methods.
https://github.com/ruby/prime/commit/883d71a659d6ba1aeaf8fcaf852ea4fbe5adcc73
https://github.com/ruby/mathn/commit/5d1c0c310f5078f42ebcb5bc282fc0ba9b578c77