### PR TITLE
Fix Prime.include?

### DIFF
--- a/lib/prime.rb
+++ b/lib/prime.rb
@@ -141,6 +141,18 @@ class Prime
     generator.each(&block)
   end
 
+  # Return true if +obj+ is an Integer an is prime.  Also returns
+  # true if +obj+ is a Module that is an ancestor of +Prime+.
+  def include?(obj)
+    case obj
+    when Integer
+      prime?(obj)
+    when Module
+      Module.instance_method(:include?).bind(Prime).call(obj)
+    else
+      false
+    end
+  end
 
   # Returns true if +value+ is a prime number, else returns false.
   #

--- a/test/test_prime.rb
+++ b/test/test_prime.rb
@@ -27,6 +27,14 @@ class TestPrime < Test::Unit::TestCase
     assert_equal PRIMES, primes
   end
 
+  def test_include?
+    assert_equal(false, Prime.include?(nil))
+    assert_equal(true, Prime.include?(3))
+    assert_equal(false, Prime.include?(4))
+    assert_equal(true, Prime.include?(Enumerable))
+    assert_equal(false, Prime.include?(Comparable))
+  end
+
   def test_integer_each_prime
     primes = []
     Integer.each_prime(1000) do |p|


### PR DESCRIPTION
Previously, it would be an infinite loop if passed a non-prime
integer.

Also, Prime.include? should also provide similar results to
Module#include? if passed a Module, so handle that.