### PR TITLE
`.int_from_prime_division` could return Rational.

### DIFF
--- a/sig/prime.rbs
+++ b/sig/prime.rbs
@@ -134,7 +134,7 @@ class Prime
   #     Prime.int_from_prime_division([[3, 2], [5, 1]])  #=> 45
   #     3**2 * 5                                         #=> 45
   #
-  def self.int_from_prime_division: (Array[[ Integer, Integer ]]) -> Integer
+  def self.int_from_prime_division: (Array[[ Integer, Integer ]]) -> (Integer | Rational)
 
   # <!--
   #   rdoc-file=lib/prime.rb
@@ -160,7 +160,7 @@ class Prime
   #     Prime.int_from_prime_division([[3, 2], [5, 1]])  #=> 45
   #     3**2 * 5                                         #=> 45
   #
-  def int_from_prime_division: (Array[[ Integer, Integer ]]) -> Integer
+  def int_from_prime_division: (Array[[ Integer, Integer ]]) -> (Integer | Rational)
 
   # <!--
   #   rdoc-file=lib/prime.rb

--- a/test/test_rbs.rb
+++ b/test/test_rbs.rb
@@ -39,6 +39,8 @@ module RBSTypeTest
     def test_int_from_prime_division
       assert_send_type "(::Array[[ ::Integer, ::Integer ]]) -> ::Integer",
                        Prime, :int_from_prime_division, [[3, 1], [19, 1]]
+      assert_send_type "(::Array[[ ::Integer, ::Integer ]]) -> ::Rational",
+                       Prime, :int_from_prime_division, [[-4, -2]]
     end
 
     def test_prime?
@@ -85,6 +87,8 @@ module RBSTypeTest
     def test_int_from_prime_division
       assert_send_type "(::Array[[ ::Integer, ::Integer ]]) -> ::Integer",
                        Prime.instance, :int_from_prime_division, [[3, 1], [19, 1]]
+      assert_send_type "(::Array[[ ::Integer, ::Integer ]]) -> ::Rational",
+                       Prime.instance, :int_from_prime_division, [[-4, -2]]
     end
 
     def test_prime?


### PR DESCRIPTION
I found pattern to return `Rational`.

There would be more patterns if the arguments were not limited to Integer, but I assume that Prime only considers Integer.