### PR TITLE
Publish RBS

### DIFF
--- a/prime.gemspec
+++ b/prime.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/prime"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
-  spec.files         = ["LICENSE.txt", "README.md", "Rakefile", "lib/prime.rb", "prime.gemspec"]
+  spec.files         = ["LICENSE.txt", "README.md", "Rakefile", "lib/prime.rb", "prime.gemspec", "sig/integer-extension.rbs", "sig/manifest.yaml", "sig/prime.rbs"]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
## Current

Currently, when a user does a `rbs collection install`, prime uses the type definition of [gem_rbs_collection](https://github.com/ruby/gem_rbs_collection/tree/5fcf7d45b7c430a651c5996280d9991c781fcf14/gems/prime/0.1.2).
prime has a history of copying the sig directory from gem_rbs_collection ([link](https://github.com/ruby/prime/pull/24)), but does not include the `sig` directory in the gem package.
rbs searches for the type definition of prime in the order of gem package -> rbs repository -> gem_rbs_collection, and uses the type definition of gem_rbs_collection found last.

## Change

Include the files in the `sig` directory in the gem package to give preference to type definitions in this repository.

## Confirmation

1. Apply this change.
2. Run in this repo.
```
$ bundle exec rake build install
```
3. Add `prime` at Gemfile in other repo.
4. Call `bundle exec rbs collection install/update` in other repo.
5. Check `prime` in `rbs_collection.lock.yaml`.
```
- name: prime
  version: 0.1.2
  source:
    type: rubygems
```