### PR TITLE
Gemfile: add logger to avoid Ruby 3.5 issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "logger"
   gem "rake"
   gem "test-unit"
   gem "test-unit-ruby-core"


### PR DESCRIPTION
In order to pass tests on Ruby 3.5.0+, we need to have access to a logger library. (Was it a dependency on the rbs library?)